### PR TITLE
Show assignee in the PR message

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -99,9 +99,14 @@ function orderPRsByRepo (prs) {
   repos.forEach(repo => {
     messages.push(`*${repo}*`)
     prsByRepo[repo].sort()
-    const prMessages = prsByRepo[repo].map(pr =>
-      `‣ [${pr.user.login}] <${pr.html_url}|${pr.number}>: ${pr.title}`
-    ).sort()
+    const prMessages = prsByRepo[repo].map(pr => {
+      const assigneeCount = pr.assignees.length
+      let assignee = ':shrug:'
+      if (assigneeCount > 0) assignee = `*${pr.assignee.login}*`
+      if (assigneeCount > 1) assignee += ` +${assigneeCount - 1}`
+      const link = `<${pr.html_url}|${pr.number}>`
+      return `‣ ${pr.user.login} ☞ ${assignee} ${link}: ${pr.title}`
+    }).sort()
     messages.push(...prMessages)
   })
   return messages


### PR DESCRIPTION
Addresses #1. Renders message with:
- no assignee shown as shrug emoji,
- assignee shown in bold, and
- additional assignees shown as +n.

![image](https://user-images.githubusercontent.com/2370911/46773332-c972bc80-ccca-11e8-8559-339f85134baf.png)

([slack message preview](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22%E2%80%A3%20trevorgerhardt%20%E2%98%9E%20%3Ashrug%3A%20%3Chttps%3A%2F%2Fgithub.com%2Fconveyal%2Fmastarm%2Fpull%2F251%7C251%3E%3A%20Use%20babel-env%20more%20appropriately%5Cn%E2%80%A3%20landonreed%20%E2%98%9E%20*evansiroky*%20%3Chttps%3A%2F%2Fgithub.com%2Fconveyal%2Fgtfs-lib%2Fpull%2F143%7C143%3E%3A%20Fix%20bad%20date%20NP%5Cn%E2%80%A3%20evansiroky%20%E2%98%9E%20*landonreed*%20%2B1%20%3Chttps%3A%2F%2Fgithub.com%2Fconveyal%2Fgtfs-lib%2Fpull%2F144%7C144%3E%3A%20Graphql%20update%22%7D))